### PR TITLE
Pass signal through transformer

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -39,9 +39,9 @@ const apiThrottler = (
     (throttler: Bottleneck) => throttler.chain(globalThrottler),
   );
 
-  const transformer: Transformer = async (prev, method, payload) => {
+  const transformer: Transformer = async (prev, method, payload, signal) => {
     if (!payload || !('chat_id' in payload)) {
-      return prev(method, payload);
+      return prev(method, payload, signal);
     }
 
     // @ts-ignore
@@ -50,7 +50,7 @@ const apiThrottler = (
     const throttler = isGroup
       ? groupThrottler.key(`${chatId}`)
       : outThrottler.key(`${chatId}`);
-    return throttler.schedule(() => prev(method, payload));
+    return throttler.schedule(() => prev(method, payload, signal));
   };
   return transformer;
 };


### PR DESCRIPTION
The transformer discards the signal. As a result, when this plugins is used, requests cannot be aborted anymore.

This PR fixes the issue by passing the signal on when calling `prev`.